### PR TITLE
Implement parametric polymorphism

### DIFF
--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -46,7 +46,7 @@ int simpl_string_print(const struct simpl_string* s) {
   return 0;
 }
 
-int simpl_tagged_size(const struct simpl_type_tag* const tag) {
+uint32_t simpl_tagged_size(const struct simpl_type_tag* const tag) {
     return tag->size;
 }
 
@@ -56,4 +56,12 @@ const struct simpl_type_tag* const simpl_tagged_tag(struct simpl_tagged_value* v
 
 void* simpl_tagged_unbox(struct simpl_tagged_value* value) {
     return value->data;
+}
+
+
+struct simpl_tagged_value* simpl_tagged_box(struct simpl_type_tag* tag, void* data) {
+    struct simpl_tagged_value *value = simpl_malloc(sizeof(struct simpl_tagged_value));
+    value->type_tag = tag;
+    value->data = data;
+    return value;
 }

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -45,3 +45,15 @@ int simpl_string_print(const struct simpl_string* s) {
   free(cstring);
   return 0;
 }
+
+int simpl_tagged_size(const struct simpl_type_tag* const tag) {
+    return tag->size;
+}
+
+const struct simpl_type_tag* const simpl_tagged_tag(struct simpl_tagged_value* value) {
+    return value->type_tag;
+}
+
+void* simpl_tagged_unbox(struct simpl_tagged_value* value) {
+    return value->data;
+}

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdint.h>
 
 #ifndef RUNTIME_H
 #define RUNTIME_H
@@ -46,20 +47,20 @@ struct simpl_type_tag {
     /**
      * The size (e.g. when compiled) of the type, in bytes.
      */
-    unsigned int size;
+    uint32_t size;
 };
 
 /**
  * Returns the size recorded in the type tag.
  */
-int simpl_tag_size(const struct simpl_type_tag* const);
+uint32_t simpl_tag_size(const struct simpl_type_tag* const);
 
 /**
  * A value tagged with its type tag. Used for polymorphic functions and
  * variables.
  */
 struct simpl_tagged_value {
-    const struct simpl_type_tag* const type_tag;
+    const struct simpl_type_tag* type_tag;
     void* data;
 };
 

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -38,4 +38,44 @@ char* simpl_string_cstring(const struct simpl_string* s);
 
 int simpl_string_print(const struct simpl_string* s);
 
+/**
+ * Describes static information about a type. This struct should not be visible
+ * from SimPL programs.
+ */
+struct simpl_type_tag {
+    /**
+     * The size (e.g. when compiled) of the type, in bytes.
+     */
+    unsigned int size;
+};
+
+/**
+ * A value tagged with its type tag. Used for polymorphic functions and
+ * variables.
+ */
+struct simpl_tagged_value {
+    const struct simpl_type_tag* const type_tag;
+    void* data;
+};
+
+/**
+ * Returns the size recorded in the type tag.
+ */
+int simpl_tag_size(const struct simpl_type_tag* const);
+
+/**
+ * Returns the type tag of a tagged value.
+ */
+const struct simpl_type_tag* const simpl_tagged_tag(struct simpl_tagged_value*);
+
+/**
+ * Returns a pointer to the boxed value of a tagged value.
+ */
+void* simpl_tagged_unbox(struct simpl_tagged_value*);
+
+/**
+ * Boxes the given value
+ */
+struct simpl_tagged_value* simpl_tagged_box(struct simpl_type_tag* tag, void* data);
+
 #endif

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -50,6 +50,11 @@ struct simpl_type_tag {
 };
 
 /**
+ * Returns the size recorded in the type tag.
+ */
+int simpl_tag_size(const struct simpl_type_tag* const);
+
+/**
  * A value tagged with its type tag. Used for polymorphic functions and
  * variables.
  */
@@ -57,11 +62,6 @@ struct simpl_tagged_value {
     const struct simpl_type_tag* const type_tag;
     void* data;
 };
-
-/**
- * Returns the size recorded in the type tag.
- */
-int simpl_tag_size(const struct simpl_type_tag* const);
 
 /**
  * Returns the type tag of a tagged value.

--- a/sample.spl
+++ b/sample.spl
@@ -5,78 +5,82 @@ data MaybeI = { JustI Double | Nothing }
 # data Barbar a = { Asdf Int a }
 
 # fun id (x : a) : a := { x }
+# 
+# fun eqargs (x : a, y : a, z: b) : a := { x }
 
-fun not (b : Bool) : Bool := { if b then false else true }
+fun main : Int := { let x = &asdf in 5 }
 
-fun and (p : Bool, q : Bool) : Bool := { if p then (if q then true else false) else false }
-
-fun or (p : Bool, q : Bool) : Bool := { if p then true else (if q then true else false) }
-
-fun factorial (x : Int) : Int := {
-  if (x <= 0) then 1
-  else x * @factorial(x - 1)
-}
-
-fun even (x: Int) : Bool := {
-  if (x <= 0) then true
-  else @not(@odd(x - 2))
-}
-
-fun odd (x: Int) : Bool := {
-  if (x <= 1) then true
-  else @not(@even(x - 2))
-}
-
-fun nested_ifs : Double := {
-  (if true then (if true then 4.0 else 5.0) else (if false then 2.0 else 3.0) + 1.0) * 2.0
-}
-
-fun main : Int := {
-  case JustI 10.0 of
-    JustI x =>
-      let msg = println("In Just branch") in
-      let mynum = @abs(-1) in
-      (if (@even(4)) then @double_me(5) else @factorial(6)) * @asdf * mynum
-    Nothing =>
-      let msg = println("In Nothing branch") in
-      let res = 4 in
-      @double_me(res + 1)
-}
-
-fun asdf : Int := {
-  (if false then 5 else 10) + 2
-}
-
-fun double_me (x : Int) : Int := { x * 2 }
-
-fun foo : Foo := {
-  Bar 5.0
-}
-
-fun foo2 : Bool := {
-  case Bar 5.0 of
-    Bar x => true
-}
-
-fun lots_of_lets : Double := {
-  let x = if true then 1.0 else 2.0 in
-  let y = if true then x * 2.0 else x * 2.0 + 1.0 in
-  y
-}
-
-fun fun_ptr : Int -> Int := { &double_me }
-
-fun fun_ptr_test (b : Bool) : Int := {
-  let f = if b then &double_me else &factorial in
-  @f(4)
-}
-
-fun cast_test_1 : Int := {
-  (1 + 1) * (cast 2.0 as Int)
-}
-
-fun cast_test_2 : Int := {
-  (1 * 1) + (cast 2.0 as Int)
-}
-
-fun abs (x : Int) : Int := extern
+# fun not (b : Bool) : Bool := { if b then false else true }
+# 
+# fun and (p : Bool, q : Bool) : Bool := { if p then (if q then true else false) else false }
+# 
+# fun or (p : Bool, q : Bool) : Bool := { if p then true else (if q then true else false) }
+# 
+# fun factorial (x : Int) : Int := {
+#   if (x <= 0) then 1
+#   else x * @factorial(x - 1)
+# }
+# 
+# fun even (x: Int) : Bool := {
+#   if (x <= 0) then true
+#   else @not(@odd(x - 2))
+# }
+# 
+# fun odd (x: Int) : Bool := {
+#   if (x <= 1) then true
+#   else @not(@even(x - 2))
+# }
+# 
+# fun nested_ifs : Double := {
+#   (if true then (if true then 4.0 else 5.0) else (if false then 2.0 else 3.0) + 1.0) * 2.0
+# }
+# 
+# fun main : Int := {
+#   case JustI 10.0 of
+#     JustI x =>
+#       let msg = println("In Just branch") in
+#       let mynum = @abs(-1) in
+#       (if (@even(4)) then @double_me(5) else @factorial(6)) * @asdf * mynum
+#     Nothing =>
+#       let msg = println("In Nothing branch") in
+#       let res = 4 in
+#       @double_me(res + 1)
+# }
+# 
+# fun asdf : Int := {
+#   (if false then 5 else 10) + 2
+# }
+# 
+# fun double_me (x : Int) : Int := { x * 2 }
+# 
+# fun foo : Foo := {
+#   Bar 5.0
+# }
+# 
+# fun foo2 : Bool := {
+#   case Bar 5.0 of
+#     Bar x => true
+# }
+# 
+# fun lots_of_lets : Double := {
+#   let x = if true then 1.0 else 2.0 in
+#   let y = if true then x * 2.0 else x * 2.0 + 1.0 in
+#   y
+# }
+# 
+# fun fun_ptr : Int -> Int := { &double_me }
+# 
+# fun fun_ptr_test (b : Bool) : Int := {
+#   let f = if b then &double_me else &factorial in
+#   @f(4)
+# }
+# 
+# fun cast_test_1 : Int := {
+#   (1 + 1) * (cast 2.0 as Int)
+# }
+# 
+# fun cast_test_2 : Int := {
+#   (1 * 1) + (cast 2.0 as Int)
+# }
+# 
+# fun abs (x : Int) : Int := extern

--- a/src/Simpl/AstToJoinIR.hs
+++ b/src/Simpl/AstToJoinIR.hs
@@ -205,8 +205,9 @@ anfTransform (Fix ae) cont = let ty = getType ae in case annGetExpr ae of
   A.Lit lit -> cont (J.JLit lit)
   A.Var name -> cont (J.JVar name)
   A.Let name bindExpr next ->
-    anfTransform bindExpr $ \bindVal ->
-      makeJexpr ty . J.JLet name bindVal <$>
+    anfTransform bindExpr $ \bindVal -> do
+      bindTy <- getJvalueType bindVal
+      makeJexpr bindTy . J.JLet name bindVal <$>
         local (insertVar name ty) (anfTransform next cont)
   A.BinOp op left right ->
     anfTransform left $ \jleft ->

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -377,6 +377,21 @@ callableCodegen callable args = case callable of
       pure $ LLVMIR.int64 0
     _ -> error $ "callableCodegen: expected 1 args to CPrint, got " ++ show (length args)
   CFunRef name -> gets (fromJust . Map.lookup name . tableFuns)
+  CTag -> case args of
+    [val] -> do
+      -- TODO: tag lookup
+      error "CTag compilation: Unimplemented"
+    _ -> error $ "callableCodegen: expected 1 args to CTag, got " ++ show (length args)
+  CUntag -> case args of
+    [jval] -> do
+      val <- jvalueCodegen jval
+      typeTag <- LLVMIR.call RT.taggedTagRef [(val, [])]
+      len <- LLVMIR.call RT.tagSizeRef [(typeTag, [])]
+      bytesPtr <- LLVMIR.call RT.taggedUnboxRef [(val, [])]
+      -- TODO: lookup LLVM type
+      -- LLVMIR.bitcast bytesPtr _
+      error "CUntag compilation: Unimplemented"
+    _ -> error $ "callableCodegen: expected 1 args to CTag, got " ++ show (length args)
 
 -- | Generates code for a [JExpr]
 jexprCodegen

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -372,13 +372,10 @@ callableCodegen callable args = case callable of
     -- Tag (index = 0)
     tagStruct2 <- LLVMIR.insertValue tagStruct1 (LLVMIR.int32 (fromIntegral ctorIndex)) [0]
     -- Data pointer (index = 1)
-    let ctorTy = LLVM.NamedTypeReference ctorName
-    let nullptr = LLVM.ConstantOperand (LLVMC.Null (LLVM.ptr ctorTy))
-    -- Use offsets to calculate struct size
-    ctorStructSize <- LLVMIR.gep nullptr [LLVMIR.int32 0]
-                      >>= flip LLVMIR.ptrtoint LLVM.i64
     -- Allocate memory for constructor.
     -- For now, use "leak memory" as an implementation strategy for deallocation.
+    let ctorTy = LLVM.NamedTypeReference ctorName
+    let ctorStructSize = LLVM.ConstantOperand (LLVMC.ZExt (LLVMC.sizeof ctorTy) LLVM.i64)
     ctorStructPtr <- LLVMIR.call RT.mallocRef [(ctorStructSize, [])] >>=
                      flip LLVMIR.bitcast (LLVM.ptr ctorTy)
     values <- traverse jvalueCodegen args

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -137,12 +137,14 @@ lookupTypeTag ty =
             TyBool -> "Bool"
             _ -> error "TODO"
       let llvmTy = typeToLLVM (Fix ty)
-      let nullptr = LLVMC.Null (LLVM.ptr RT.typeTagType)
       let size = LLVMC.sizeof llvmTy
       let tagContents = LLVMC.Struct { LLVMC.structName = Nothing
                                      , LLVMC.isPacked = False
                                      , LLVMC.memberValues = [size] }
-      LLVMIR.global (LLVM.mkName $ "simpl.tag." ++ name) RT.typeTagType tagContents
+      let lname = LLVM.mkName $ "simpl.tag." ++ Text.unpack name
+      oper <- LLVMIR.global lname RT.typeTagType tagContents
+      modify (\t -> t { tableTypeTags = Map.insert ty oper (tableTypeTags t) })
+      pure oper
 
 bindVariable :: MonadState CodegenTable m
              => Text

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -406,6 +406,8 @@ callableCodegen callable args = case callable of
       ty <- lookupValueType jval
       val <- jvalueCodegen jval
       tag <- lookupTypeTag ty
+      -- TODO: Box primitive types like int, bool, etc.; should require a malloc
+      -- and store
       bytes <- LLVMIR.bitcast val (LLVM.ptr LLVM.void)
       LLVMIR.call RT.taggedBoxRef [(tag, []), (bytes, [])]
     _ -> error $ "callableCodegen: expected 1 args to CTag, got " ++ show (length args)

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -462,7 +462,8 @@ typeToLLVM = go . unfix
             , LLVM.argumentTypes = typeToLLVM <$> args
             , LLVM.isVarArg = False
             }
-      TyVar _ -> error "compilation of parametrically polymorphic functions not implemented yet"
+      TyVar _ -> RT.taggedValueType
+      TyBox _ -> RT.taggedValueType
 
 adtToLLVM :: Text
            -> [Constructor]

--- a/src/Simpl/Backend/Codegen.hs
+++ b/src/Simpl/Backend/Codegen.hs
@@ -132,9 +132,10 @@ lookupTypeTag ty =
     Just oper -> pure oper
     Nothing -> do
       let name = case ty of
-            TyNumber _ -> "Int" -- TODO: fix this
-            TyString -> "String"
+            TyNumber NumInt -> "Int"
+            TyNumber NumDouble -> "Double"
             TyBool -> "Bool"
+            TyString -> "String"
             TyAdt n _ -> "data." <> n
             x -> error ("TODO: handle tag type lookup for " ++ show x)
       let llvmTy = typeToLLVM (Fix ty)
@@ -571,8 +572,8 @@ moduleCodegen srcCode symTab = mdo
   -- Insert function operands into symbol table before emitting so order of
   -- definition doesn't matter. This works because the codegen monad is lazy.
   modify (\t -> t { tableFuns = tableFuns t `Map.union` Map.fromList funOpers })
-  -- TODO: Care about type variables
   funOpers <- forM (Map.toList . symTabFuns $ symTab) $ \(name, (_, params, ty, body)) ->
+    -- Ignore type variables since they're handled with boxing code
     (name, ) <$> funToLLVM name params ty body
 
   _ <- LLVMIR.function "main" [] LLVM.i64 $ \_ -> do

--- a/src/Simpl/Backend/Runtime.hs
+++ b/src/Simpl/Backend/Runtime.hs
@@ -97,13 +97,39 @@ stringFuns = [ ("simpl_string_cstring", stringCstringType)
 stringStructs :: [String]
 stringStructs = ["simpl_string"]
 
+-- * Tags
+
+typeTagType :: LLVM.Type
+typeTagType = runtimeStruct "simpl_type_tag"
+
+taggedValueType :: LLVM.Type
+taggedValueType = runtimeStruct "simpl_tagged_value"
+
+tagSizeType, taggedTagType, taggedUnboxType :: FunType
+tagSizeType = mkFunType [("t", LLVM.ptr typeTagType)] LLVM.i64
+taggedTagType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr taggedValueType)
+taggedUnboxType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr LLVM.void)
+
+tagSizeRef, taggedTagRef, taggedUnboxRef :: LLVM.Operand
+tagSizeRef = runtimeFunRef "simpl_tag_size" tagSizeType
+taggedTagRef = runtimeFunRef "simpl_tagged_tag" taggedTagType
+taggedUnboxRef = runtimeFunRef "simpl_tagged_unbox" taggedUnboxType
+
+runtimeTypeFuns :: [(String, FunType)]
+runtimeTypeFuns = [ ("simpl_tag_size", tagSizeType)
+                  , ("simpl_tagged_tag", taggedTagType)
+                  , ("simpl_tagged_unbox", taggedUnboxType) ]
+
+runtimeTypeStructs :: [String]
+runtimeTypeStructs = ["simpl_type_tag", "simpl_tagged_value"]
+
 -- * Entire runtime
 
 allRuntimeFuns :: [(String, FunType)]
-allRuntimeFuns = join [cstdlibFuns, stringFuns]
+allRuntimeFuns = join [cstdlibFuns, stringFuns, runtimeTypeFuns]
 
 allRuntimeStructs :: [String]
-allRuntimeStructs = stringStructs
+allRuntimeStructs = stringStructs ++ runtimeTypeStructs
 
 emitRuntimeDecls :: LLVMIR.MonadModuleBuilder m => m ()
 emitRuntimeDecls = do

--- a/src/Simpl/Backend/Runtime.hs
+++ b/src/Simpl/Backend/Runtime.hs
@@ -64,8 +64,8 @@ mallocType = mkFunType [("ptr", LLVM.i64)] (LLVM.ptr LLVM.i8)
 memcpyType = mkFunType [ ("dest", LLVM.ptr LLVM.i8)
                        , ("src", LLVM.ptr LLVM.i8)
                        , ("len", LLVM.i64) ]
-                       LLVM.void
-printfType = ([("", LLVM.ptr LLVM.i8)], LLVM.void, True)
+                       LLVM.i8
+printfType = ([("", LLVM.ptr LLVM.i8)], LLVM.i8, True)
 
 mallocRef, memcpyRef, printfRef :: LLVM.Operand
 mallocRef = runtimeFunRef "simpl_malloc" mallocType
@@ -111,8 +111,8 @@ taggedValueType = runtimeStruct "simpl_tagged_value"
 tagSizeType, taggedTagType, taggedBoxType, taggedUnboxType :: FunType
 tagSizeType = mkFunType [("t", LLVM.ptr typeTagType)] LLVM.i64
 taggedTagType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr taggedValueType)
-taggedBoxType = mkFunType [("t", LLVM.ptr typeTagType), ("d", LLVM.ptr LLVM.void)] (LLVM.ptr taggedValueType)
-taggedUnboxType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr LLVM.void)
+taggedBoxType = mkFunType [("t", LLVM.ptr typeTagType), ("d", LLVM.ptr LLVM.i8)] (LLVM.ptr taggedValueType)
+taggedUnboxType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr LLVM.i8)
 
 tagSizeRef, taggedTagRef, taggedBoxRef, taggedUnboxRef :: LLVM.Operand
 tagSizeRef = runtimeFunRef "simpl_tag_size" tagSizeType

--- a/src/Simpl/Backend/Runtime.hs
+++ b/src/Simpl/Backend/Runtime.hs
@@ -109,16 +109,19 @@ tagSizeType, taggedTagType, taggedUnboxType :: FunType
 tagSizeType = mkFunType [("t", LLVM.ptr typeTagType)] LLVM.i64
 taggedTagType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr taggedValueType)
 taggedUnboxType = mkFunType [("t", LLVM.ptr taggedValueType)] (LLVM.ptr LLVM.void)
+taggedBoxType = mkFunType [("t", LLVM.ptr taggedValueType), ("d", LLVM.ptr LLVM.void)] (LLVM.ptr typeTagType)
 
 tagSizeRef, taggedTagRef, taggedUnboxRef :: LLVM.Operand
 tagSizeRef = runtimeFunRef "simpl_tag_size" tagSizeType
 taggedTagRef = runtimeFunRef "simpl_tagged_tag" taggedTagType
 taggedUnboxRef = runtimeFunRef "simpl_tagged_unbox" taggedUnboxType
+taggedBoxRef = runtimeFunRef "simpl_tagged_box" taggedBoxType
 
 runtimeTypeFuns :: [(String, FunType)]
 runtimeTypeFuns = [ ("simpl_tag_size", tagSizeType)
                   , ("simpl_tagged_tag", taggedTagType)
-                  , ("simpl_tagged_unbox", taggedUnboxType) ]
+                  , ("simpl_tagged_unbox", taggedUnboxType)
+                  , ("simpl_tagged_box", taggedBoxType) ]
 
 runtimeTypeStructs :: [String]
 runtimeTypeStructs = ["simpl_type_tag", "simpl_tagged_value"]

--- a/src/Simpl/JoinIR/Syntax.hs
+++ b/src/Simpl/JoinIR/Syntax.hs
@@ -39,6 +39,8 @@ data Callable
   | CCtor !Name -- ^ ADT constructor
   | CPrint -- ^ Print string (temporary)
   | CFunRef !Name -- ^ Static function reference
+  | CTag -- ^ Create a boxed representation of the given value
+  | CUntag -- ^ Unbox the value
   deriving (Show)
 
 -- | A value
@@ -124,6 +126,8 @@ instance Pretty Callable where
     CCtor name -> pretty name
     CPrint -> "print"
     CFunRef name -> "funref[" <> pretty name <> "]"
+    CTag -> "tag"
+    CUntag -> "untag"
 
 instance Pretty JValue where
   pretty = \case

--- a/src/Simpl/JoinIR/Syntax.hs
+++ b/src/Simpl/JoinIR/Syntax.hs
@@ -23,7 +23,7 @@ import Data.Text.Prettyprint.Doc (Pretty, pretty, (<>), (<+>))
 import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Simpl.Annotation as Ann
 import Simpl.Ast (BinaryOp(..), Literal(..))
-import Simpl.Type (Numeric(..))
+import Simpl.Type (Numeric(..), Type)
 import Text.Show.Deriving (deriveShow1)
 import Data.Functor.Foldable
 
@@ -66,14 +66,14 @@ data ControlFlow a
 
 
 data JBranch a
-  = BrAdt Name [Name] !(Cfe a) -- ^ Destructure algebraic data type
+  = BrAdt Name [(Name, Type)] !(Cfe a) -- ^ Destructure algebraic data type
   deriving (Functor, Foldable, Traversable, Show)
 
 branchGetExpr :: JBranch a -> a
 branchGetExpr = \case
   BrAdt _ _ (Cfe e _) -> e
 
-branchGetBindings :: JBranch a -> [Text]
+branchGetBindings :: JBranch a -> [(Text, Type)]
 branchGetBindings = \case
   BrAdt _ vars _ -> vars
 
@@ -135,9 +135,11 @@ instance Pretty JValue where
     JLit l -> pretty l
 
 instance Pretty a => Pretty (JBranch a) where
-  pretty (BrAdt ctorName varNames cfe) =
-    PP.hang 2 $ PP.hsep (pretty <$> brPart) <> PP.softline <> pretty cfe
-    where brPart = [ctorName] ++ varNames ++ ["=>"]
+  pretty (BrAdt ctorName varPairs cfe) =
+    PP.hang 2 $ PP.hsep brPart <> PP.softline <> pretty cfe
+    where
+      vars = (\(n, t) -> PP.parens (pretty n <+> ":" <+> pretty t)) <$> varPairs
+      brPart = [pretty ctorName] ++ vars ++ [pretty ("=>" :: Text)]
 
 instance Pretty a => Pretty (ControlFlow a) where
   pretty = \case

--- a/src/Simpl/JoinIR/Verify.hs
+++ b/src/Simpl/JoinIR/Verify.hs
@@ -142,5 +142,5 @@ doVerifyBranch :: (MonadError VerifyError m, MonadReader VerifyCtx m)
                -> m ()
 doVerifyBranch (BrAdt name args cfe) = do
   checkUnboundVar name
-  _ <- traverse checkUnboundVar args
+  _ <- traverse checkUnboundVar (fst <$> args)
   doVerifyCfe cfe

--- a/src/Simpl/Parser.hs
+++ b/src/Simpl/Parser.hs
@@ -184,7 +184,7 @@ typeVar = Fix . TyVar <$> identifier
 typeAdt :: Parser m Type
 typeAdt = do
   name <- typeIdentifier
-  tparams <- many typeVar
+  tparams <- many (parens type' <|> type')
   pure $ Fix (TyAdt name tparams)
 
 typeAtom :: Parser m Type
@@ -228,7 +228,7 @@ declFun = lexeme $
 constructor :: Parser m Ast.Constructor
 constructor = lexeme $ do
   name <- typeIdentifier
-  args <- many type'
+  args <- many (parens type' <|> type')
   pure $ Ast.Ctor name args
 
 declAdt :: Parser m (Decl SourcedExpr)

--- a/src/Simpl/Parser.hs
+++ b/src/Simpl/Parser.hs
@@ -188,7 +188,7 @@ typeAdt = do
   pure $ Fix (TyAdt name tparams)
 
 typeAtom :: Parser m Type
-typeAtom = typeLit <|> typeAdt
+typeAtom = typeLit <|> typeAdt <|> typeVar
 
 typeFun :: Parser m Type
 typeFun = lexeme $ do
@@ -198,7 +198,7 @@ typeFun = lexeme $ do
   pure . Fix $ TyFun (first : init rest) (last rest)
 
 type' :: Parser m Type
-type' = try typeFun <|> typeAtom <|> typeVar <?> "type"
+type' = try typeFun <|> typeAtom <?> "type"
 
 declFunParamList :: Parser m [(Text, Type)]
 declFunParamList = lexeme $ option [] (parens params)

--- a/src/Simpl/SymbolTable.hs
+++ b/src/Simpl/SymbolTable.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 module Simpl.SymbolTable where
 
+import Control.Applicative ((<|>))
 import Data.List (find)
 import Data.Maybe (mapMaybe, listToMaybe)
 import Data.Map.Strict (Map)
@@ -90,3 +91,8 @@ symTabLookupStaticFun name = Map.lookup name . symTabFuns
 
 symTabLookupExternFun :: Text -> SymbolTable e -> Maybe ([(Text, Type)], Type)
 symTabLookupExternFun name = Map.lookup name . symTabExtern
+
+symTabLookupFun :: Text -> SymbolTable e -> Maybe (Set Text, [(Text, Type)], Type)
+symTabLookupFun name tab = static tab <|> extern tab
+  where static = fmap (\(tvars, p, r, _) -> (tvars, p, r)) . symTabLookupStaticFun name
+        extern = fmap (\(p, r) -> (Set.empty, p, r)) . symTabLookupExternFun name

--- a/src/Simpl/SymbolTable.hs
+++ b/src/Simpl/SymbolTable.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DeriveTraversable #-}
 module Simpl.SymbolTable where
 
-import Data.Functor.Foldable (Fix(Fix))
 import Data.List (find)
 import Data.Maybe (mapMaybe, listToMaybe)
 import Data.Map.Strict (Map)
@@ -17,7 +16,7 @@ import Simpl.Ast
 import Simpl.Type
 
 data SymbolTable expr = MkSymbolTable
-  { symTabAdts :: Map Text (Type, [Constructor])
+  { symTabAdts :: Map Text ([Text], [Constructor]) -- ^ ADT definitions: name, type vars, constructors
   , symTabFuns :: Map Text (Set Text, [(Text, Type)], Type, expr) -- ^ Static functions: free type vars, params, return type, body
   , symTabVars :: Map Text Type -- ^ Variables
   , symTabExtern :: Map Text ([(Text, Type)], Type) -- ^ External functions
@@ -29,7 +28,7 @@ buildSymbolTable (SourceFile _ decls) =
   let adts = Map.fromList $ mapMaybe
         (\case
           DeclAdt name tparams ctors ->
-            Just (name, (Fix (TyAdt name (Fix . TyVar <$> tparams)), ctors))
+            Just (name, (tparams, ctors))
           _ -> Nothing) decls
       funs = Map.fromList $ mapMaybe
         (\case
@@ -47,7 +46,7 @@ buildSymbolTable (SourceFile _ decls) =
      , symTabVars = Map.empty
      , symTabExtern = extern }
 
-symTabModifyAdts :: (Map Text (Type, [Constructor]) -> Map Text (Type, [Constructor]))
+symTabModifyAdts :: (Map Text ([Text], [Constructor]) -> Map Text ([Text], [Constructor]))
                  -> SymbolTable e
                  -> SymbolTable e
 symTabModifyAdts f t = t { symTabAdts = f (symTabAdts t) }
@@ -68,13 +67,13 @@ symTabTraverseExprs f t = do
 
 -- | Searches for the given constructor, returning the name of the ADT, the
 -- constructor, and the index of the constructor.
-symTabLookupCtor :: Text -> SymbolTable e -> Maybe (Type, Constructor, Int)
+symTabLookupCtor :: Text -> SymbolTable e -> Maybe ((Text, [Text]), Constructor, Int)
 symTabLookupCtor name t = listToMaybe . mapMaybe (find isTheCtor) $ getCtors
   where
-    getCtors = (\(ty, cs) -> zip3 (repeat ty) cs [0..]) <$> Map.elems (symTabAdts t)
+    getCtors = (\(tname, (tvars, cs)) -> zip3 (repeat (tname, tvars)) cs [0..]) <$> Map.toList (symTabAdts t)
     isTheCtor (_, Ctor ctorName _, _) = ctorName == name
 
-symTabLookupAdt :: Text -> SymbolTable e -> Maybe (Type, [Constructor])
+symTabLookupAdt :: Text -> SymbolTable e -> Maybe ([Text], [Constructor])
 symTabLookupAdt name = Map.lookup name . symTabAdts
 
 symTabLookupVar :: Text -> SymbolTable e -> Maybe Type

--- a/src/Simpl/Type.hs
+++ b/src/Simpl/Type.hs
@@ -15,6 +15,7 @@ import Data.Functor.Foldable (Fix(Fix), para, cata)
 import Data.Text (Text)
 import Data.Text.Prettyprint.Doc
 import Data.Eq.Deriving (deriveEq1)
+import Data.Ord.Deriving (deriveOrd1)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Text.Show.Deriving (deriveShow1)
@@ -25,7 +26,7 @@ import Text.Show.Deriving (deriveShow1)
 data Numeric = NumDouble -- ^ 64-bit floating point
              | NumInt -- ^ 64-bit signed integer
              | NumUnknown -- ^ Unknown (defaults to 64-bit floating point)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
 instance Pretty Numeric where
   pretty = \case
@@ -42,12 +43,13 @@ data TypeF a
   | TyFun [a] a
   | TyVar Text
   | TyBox a -- ^ Boxed polymorphic type
-  deriving (Show, Functor, Foldable, Traversable)
+  deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
 type Type = Fix TypeF
 
 $(deriveShow1 ''TypeF)
 $(deriveEq1 ''TypeF)
+$(deriveOrd1 ''TypeF)
 
 instance Unifiable TypeF where
   zipMatch (TyNumber n) (TyNumber m) = case (n, m) of

--- a/src/Simpl/Type.hs
+++ b/src/Simpl/Type.hs
@@ -119,7 +119,7 @@ instance Pretty Type where
       go (TyNumber n) = pretty n
       go TyBool = "Bool"
       go TyString = "String"
-      go (TyAdt n tparams) = pretty n <> hsep (snd <$> tparams)
+      go (TyAdt n tparams) = hsep (pretty n : (snd <$> tparams))
       go (TyFun args res) =
         encloseSep mempty mempty " -> " (wrapComplex <$> args ++ [res])
       go (TyVar n) = pretty n

--- a/src/Simpl/Type.hs
+++ b/src/Simpl/Type.hs
@@ -16,6 +16,8 @@ import Data.Text (Text)
 import Data.Text.Prettyprint.Doc
 import Data.Eq.Deriving (deriveEq1)
 import Data.Ord.Deriving (deriveOrd1)
+import Data.Map (Map)
+import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Text.Show.Deriving (deriveShow1)
@@ -78,6 +80,14 @@ isComplexType = \case
   TyFun _ _ -> True
   _ -> False
 
+-- | Whether a type is represented using a pointer
+typeRepIsPtr :: TypeF Type -> Bool
+typeRepIsPtr = \case
+  TyNumber _ -> False
+  TyBool -> False
+  TyAdt _ _ -> False
+  _ -> True
+
 functionTypeResult :: Type -> Type
 functionTypeResult (Fix ty) = case ty of
   TyFun _ res -> functionTypeResult res
@@ -93,6 +103,12 @@ getTypeVars = cata $ \case
   TyAdt _ vargs -> Set.unions vargs
   TyBox vs -> vs
 
+substituteTypeVars :: Map Text Type -> Type -> Type
+substituteTypeVars vars = cata go
+  where
+    go = \case
+      ty@(TyVar n) -> Map.findWithDefault (Fix ty) n vars
+      ty -> Fix ty
 
 instance Pretty Type where
   pretty = para go

--- a/src/Simpl/Typecheck.hs
+++ b/src/Simpl/Typecheck.hs
@@ -172,7 +172,7 @@ inferType = cata $ \ae -> case annGetExpr ae of
     (tvars, params, ty) <- lookupFun name (extractTy <$> argsTc)
     -- Check parameter count
     let numParams = length params
-    let paramCount = length params
+    let paramCount = length args
     when (numParams /= paramCount) $
       throwError $ TyErrArgCount numParams paramCount params
     let unifyExprTy expr pTy =

--- a/src/Simpl/Typecheck.hs
+++ b/src/Simpl/Typecheck.hs
@@ -266,6 +266,7 @@ typeToUtype = cata $ \case
   TyAdt n tparams -> UTerm (TyAdt n tparams) -- TODO: Instantiate variables somewhere
   TyFun args res -> UTerm (TyFun args res)
   TyVar n -> UTerm (TyVar n)
+  TyBox _ -> error "TyBox should not be in SimPL AST"
 
 -- | Instantiate the type variables with new unification variables
 instantiateVars :: Set Text -> Typecheck fields (Map.Map Text UType)

--- a/test-suite/poly-data.spl
+++ b/test-suite/poly-data.spl
@@ -1,0 +1,8 @@
+data Maybe a = { Just a | Nothing }
+
+fun main : Int := {
+  let foo = Just 5 in # 0
+  case foo of
+    Just x => let _ = println("Just OK") in x
+    Nothing => let _ = println("ERROR: Got Nothing") in 0
+}

--- a/test-suite/poly-data.spl
+++ b/test-suite/poly-data.spl
@@ -57,3 +57,19 @@ fun main : Int := {
   let x2 = @printList(@filter(nums, &lte5), "filter(numberList, <= 5)") in
   x2
 }
+
+data AddTable a = { Add (a -> a -> a) }
+
+fun add (x : a, y : a, table : AddTable a) : a := {
+  case table of
+    Add f => @f(x, y)
+}
+
+fun add_Int (x : Int, y : Int) : Int := {
+  x + y
+}
+
+fun addTable_Int : AddTable Int := {
+  let f = &add_Int in
+  Add f
+}

--- a/test-suite/poly-data.spl
+++ b/test-suite/poly-data.spl
@@ -16,18 +16,44 @@ fun head (xs : List a) : Maybe a := {
     Cons h t => Just h
 }
 
+# FIXME: passing a function ref w/ unboxed argument to a function
+# requiring a function ref w/ boxed argument does not work.
+# Passed function ref needs to be automatically "promoted" to a
+# boxed version.
+
+# fun filter (xs : List a, f : a -> Bool) : List a := {
+#   case xs of
+#     Nil => Nil
+#     Cons h t => if @f(h) then Cons h @filter(t, f) else @filter(t, f)
+# }
+
+fun filter (xs : List Int, f : Int -> Bool) : List Int := {
+  case xs of
+    Nil => Nil
+    Cons h t =>
+      let newT = @filter(t, f) in
+      if @f(h) then Cons h newT else newT
+}
+
+fun lte5 (x: Int) : Bool := {
+  x <= 5
+}
+
 fun numberList (n : Int) : List Int := {
   if n <= 0 then Nil else Cons n @numberList(n - 1)
 }
 
-fun printList (xs : List a) : Int := {
+fun printList (xs : List a, msg : String) : Int := {
   case xs of
     Nil => 0
     Cons h t =>
-      let _ = println("Item") in
-      @printList(t)
+      let _ = println(msg) in
+      @printList(t, msg)
 }
 
 fun main : Int := {
-  @printList(@numberList(10))
+  let nums = @numberList(10) in
+  let x1 = @printList(nums, "numberList") in
+  let x2 = @printList(@filter(nums, &lte5), "filter(numberList, <= 5)") in
+  x2
 }

--- a/test-suite/poly-data.spl
+++ b/test-suite/poly-data.spl
@@ -1,8 +1,33 @@
 data Maybe a = { Just a | Nothing }
 
-fun main : Int := {
+fun testJust : Int := {
   let foo = Just 5 in # 0
-  case foo of
-    Just x => let _ = println("Just OK") in x
+  let asdf = case foo of
+    Just x => let _ = println("Got Just!") in x
     Nothing => let _ = println("ERROR: Got Nothing") in 0
+  in asdf
+}
+
+data List a = { Nil | Cons a (List a) }
+
+fun head (xs : List a) : Maybe a := {
+  case xs of
+    Nil => Nothing
+    Cons h t => Just h
+}
+
+fun numberList (n : Int) : List Int := {
+  if n <= 0 then Nil else Cons n @numberList(n - 1)
+}
+
+fun printList (xs : List a) : Int := {
+  case xs of
+    Nil => 0
+    Cons h t =>
+      let _ = println("Item") in
+      @printList(t)
+}
+
+fun main : Int := {
+  @printList(@numberList(10))
 }

--- a/test-suite/polymorphism.spl
+++ b/test-suite/polymorphism.spl
@@ -2,5 +2,8 @@ fun id (x: a) : a := { x }
 
 fun main : Int := {
     let _ = println(@id("hi")) in
+    let y = 5 in
+    let _ = println(if true then @id("bye") else "sigh") in
+#    let _ = println(if @id(y) <= 0 then @id("bye") else "sigh") in
     0
 }

--- a/test-suite/polymorphism.spl
+++ b/test-suite/polymorphism.spl
@@ -1,5 +1,19 @@
 fun id (x: a) : a := { x }
 
+data Foo = { Bar Int | Nope }
+
+fun test_data (f : Foo) : Foo := {
+  case @id(f) of
+    Bar y => f
+    Nope => f
+}
+
+fun test_case (x : Int) : String := {
+  @id(case Bar x of
+    Bar y => @id("hi")
+    Nope => "bye")
+}
+
 fun main : Int := {
     let _ = println(@id("hi")) in
     let y = 5 in

--- a/test-suite/polymorphism.spl
+++ b/test-suite/polymorphism.spl
@@ -14,6 +14,10 @@ fun test_case (x : Int) : String := {
     Nope => "bye")
 }
 
+fun hi : String := {
+  let f = &test_case in @test_case(0)
+}
+
 fun main : Int := {
     let _ = println(@id("hi")) in
     let y = 5 in

--- a/test-suite/polymorphism.spl
+++ b/test-suite/polymorphism.spl
@@ -1,0 +1,6 @@
+fun id (x: a) : a := { x }
+
+fun main : Int := {
+    let _ = println(@id("hi")) in
+    0
+}

--- a/test.sh
+++ b/test.sh
@@ -13,5 +13,5 @@ for src_file in $(find "$TEST_DIR" -type f -name '*.spl'); do
     out_name="$TEST_BIN_DIR/$out_name"
     echo "Building ${out_name%.o}..."
     stack exec simplc -- "$src_file" -o "$out_name" $COMPILER_ARGS
-    clang -g -pthread runtime/libgc.a "$out_name" -o "${out_name%.o}" -lm
+    clang -g -pthread "$out_name" runtime/libgc.a -o "${out_name%.o}" -lm
 done


### PR DESCRIPTION
Includes:

* Parametric polymorphism in functions
* Rank 1 type constructors
* Fix constructor memory allocation (previously allocated 0 bytes, I think)
* Polymorphism is implemented by passing values in a "tag"/box wrapper during runtime. Primitive values such as integers, booleans, and ADTs are boxed during conversion from AST to JoinIR.

Caveats:
* Arguments to a function reference are not automatically boxed/unboxed yet. This requires creating wrappers for function references if boxing/unboxing is needed (e.g. a generic `filter` function over a concrete linked list).